### PR TITLE
skip PIT visual tests until new rstantools is released

### DIFF
--- a/tests/testthat/test-ppc-loo.R
+++ b/tests/testthat/test-ppc-loo.R
@@ -213,6 +213,7 @@ test_that("ppc_loo_pit_overlay renders correctly", {
   skip_if_not_installed("vdiffr")
   skip_if_not_installed("loo")
   skip_on_r_oldrel()
+  skip_if(packageVersion("rstantools") > "2.4.0")
 
   p_base <- suppressMessages(ppc_loo_pit_overlay(vdiff_loo_y, vdiff_loo_yrep, vdiff_loo_lw))
   vdiffr::expect_doppelganger("ppc_loo_pit_overlay (default)", p_base)
@@ -231,6 +232,7 @@ test_that("ppc_loo_pit_qq renders correctly", {
   skip_if_not_installed("vdiffr")
   skip_if_not_installed("loo")
   skip_on_r_oldrel()
+  skip_if(packageVersion("rstantools") > "2.4.0")
 
   p_base <- ppc_loo_pit_qq(vdiff_loo_y, vdiff_loo_yrep, vdiff_loo_lw)
   vdiffr::expect_doppelganger("ppc_loo_pit_qq (default)", p_base)
@@ -305,6 +307,7 @@ test_that("ppc_loo_pit_ecdf renders correctly", {
   skip_if_not_installed("vdiffr")
   skip_if_not_installed("loo")
   skip_on_r_oldrel()
+  skip_if(packageVersion("rstantools") <= "2.4.0")
 
   psis_object <- suppressWarnings(loo::psis(-vdiff_loo_lw))
   p_base <- ppc_loo_pit_ecdf(


### PR DESCRIPTION
I will be finally releasing the next version of rstantools soon, but the updated PIT algorithm breaks a few visual tests in bayesplot. This PR disables those tests. I will reenable them and update them to the new rstantools after releasing rstantools. 

I will probably do a release of bayesplot in the next few days (including this PR and also everything @behramulukir has added so far) in order to make sure these tests are disabled on CRAN so that the rstantools submission doesn't break the version of bayesplot on CRAN. 
