### PR TITLE
Floating major version for GH pages deploy action. (JamesIves)

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -54,7 +54,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.7.4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           clean: false
           branch: gh-pages


### PR DESCRIPTION
Moves to a floating reference (v4 instead of v4.x.x). See discussion at https://github.com/stan-dev/bayesplot/pull/401#discussion_r2651994031.

Obviates #401.