### PR TITLE
Fix ggplot2 ‘Groups with fewer than two datapoints’ warning in mcmc_nuts_treedepth()

### DIFF
--- a/R/mcmc-diagnostics-nuts.R
+++ b/R/mcmc-diagnostics-nuts.R
@@ -369,19 +369,29 @@ mcmc_nuts_treedepth <- function(x, lp, chain = NULL, ...) {
     yaxis_ticks(FALSE)
 
   violin_lp_data <- data.frame(treedepth, lp = lp$Value)
+
+  # Only keep treedepth values that occur more than once for violin plot
+  value_counts <- table(violin_lp_data$Value)
+  keep_values <- names(value_counts[value_counts > 1])
+  violin_lp_data <- violin_lp_data[violin_lp_data$Value %in% keep_values, ]
+
   violin_lp <-
     ggplot(violin_lp_data, aes(x = factor(.data$Value), y = .data$lp)) +
     geom_violin(fill = get_color("l"), color = get_color("lh")) +
     labs(x = "treedepth__", y = "lp__") +
-    scale_x_discrete(drop = FALSE) +
     bayesplot_theme_get()
 
   violin_accept_stat_data <- data.frame(treedepth, as = accept_stat$Value)
+
+  # Only keep treedepth values that occur more than once for violin plot
+  value_counts <- table(violin_accept_stat_data$Value)
+  keep_values <- names(value_counts[value_counts > 1])
+  violin_accept_stat_data <- violin_accept_stat_data[violin_accept_stat_data$Value %in% keep_values, ]
+
   violin_accept_stat <-
     ggplot(violin_accept_stat_data, aes(x = factor(.data$Value), y = .data$as)) +
     geom_violin(fill = get_color("l"), color = get_color("lh")) +
     labs(x = "treedepth__", y = "accept_stat__") +
-    scale_x_discrete(drop = FALSE) +
     scale_y_continuous(breaks = c(0, 0.5, 1)) +
     bayesplot_theme_get()
 
@@ -410,7 +420,6 @@ mcmc_nuts_treedepth <- function(x, lp, chain = NULL, ...) {
   )
   as_bayesplot_grid(nuts_plot)
 }
-
 
 #' @rdname MCMC-nuts
 #' @export


### PR DESCRIPTION
Currently, the following gives a warning (taken from test-mcmc-nuts.R)

```{r}
> if (requireNamespace("rstanarm", quietly = TRUE)) {
+     ITER <- 1000
+     CHAINS <- 3
+     fit <- rstanarm::stan_glm(mpg ~ wt + am, data = mtcars,
+                               iter = ITER, chains = CHAINS,
+                               refresh = 0)
+     np <- nuts_params(fit)
+     lp <- log_posterior(fit)
+ }
> 
> mcmc_nuts_treedepth(np, lp, chain = CHAINS)
Warning messages:
1: Groups with fewer than two datapoints have been dropped.
ℹ Set `drop = FALSE` to consider such groups for position adjustment purposes. 
2: Groups with fewer than two datapoints have been dropped.
ℹ Set `drop = FALSE` to consider such groups for position adjustment purposes.
```

This PR fixes the issue by filtering that there are at least 2 observations before calling `geom_violin`, so the dropping doesn't happen implicitly with a warning.