### PR TITLE
Clarify MCMC-nuts chain argument documentation for `mcmc_nuts_stepsize()`.

### DIFF
--- a/R/mcmc-diagnostics-nuts.R
+++ b/R/mcmc-diagnostics-nuts.R
@@ -19,8 +19,9 @@
 #' @param chain A positive integer for selecting a particular chain. The default
 #'   (`NULL`) is to merge the chains before plotting. If `chain = k`
 #'   then the plot for chain `k` is overlaid (in a darker shade but with
-#'   transparency) on top of the plot for all chains. The `chain` argument
-#'   is not used by `mcmc_nuts_energy()`.
+#'   transparency) on top of the plot for all chains. For `mcmc_nuts_stepsize()`,
+#'   chains are always plotted separately, and `chain` simply highlights the
+#'   selected chain. The `chain` argument is not used by `mcmc_nuts_energy()`.
 #' @param ... Currently ignored.
 #'
 #' @return A gtable object (the result of calling
@@ -284,7 +285,6 @@ mcmc_nuts_divergence <- function(x, lp, chain = NULL, ...) {
   nuts_plot <- gridExtra::arrangeGrob(violin_lp, violin_accept_stat, nrow = 2)
   as_bayesplot_grid(nuts_plot)
 }
-
 
 #' @rdname MCMC-nuts
 #' @export

--- a/man/MCMC-nuts.Rd
+++ b/man/MCMC-nuts.Rd
@@ -50,8 +50,9 @@ object with the same form as the object returned by
 \item{chain}{A positive integer for selecting a particular chain. The default
 (\code{NULL}) is to merge the chains before plotting. If \code{chain = k}
 then the plot for chain \code{k} is overlaid (in a darker shade but with
-transparency) on top of the plot for all chains. The \code{chain} argument
-is not used by \code{mcmc_nuts_energy()}.}
+transparency) on top of the plot for all chains. For \code{mcmc_nuts_stepsize()},
+chains are always plotted separately, and \code{chain} simply highlights the
+selected chain. The \code{chain} argument is not used by \code{mcmc_nuts_energy()}.}
 
 \item{...}{Currently ignored.}
 


### PR DESCRIPTION
The default behavior for `mcmc_nuts_stepsize()` and what the argument `chain` does is different than for the rest. Updated the documentation to reflect this.