### PR TITLE
Fix deprecated formula syntax in aes() call

### DIFF
--- a/R/mcmc-distributions.R
+++ b/R/mcmc-distributions.R
@@ -489,7 +489,7 @@ mcmc_dots_by_chain <- function(
   data <- melt_mcmc(x, value.name = "value")
   n_param <- num_params(data)
 
-  graph <- ggplot(data, aes(x = ~ value)) +
+  graph <- ggplot(data, aes(x = .data$value)) +
     geom_histogram(
       set_hist_aes(freq),
       fill = get_color("mid"),


### PR DESCRIPTION
Fixes #441

Replaced `aes(x = ~ value)` with `aes(x = .data$value)` in `R/mcmc-distributions.R`. This was the last remaining use of the deprecated formula syntax in `aes()`.