### PR TITLE
Fix override.aes size to linewidth for linetype legend (#449)

### DIFF
--- a/R/bayesplot-helpers.R
+++ b/R/bayesplot-helpers.R
@@ -21,7 +21,7 @@
 #'   [ggplot2::element_line()].
 #'
 #'   For `overlay_function`, `...` is passed to
-#'   [ggplot2::geom_function()].
+#'   [ggplot2::stat_function()].
 #'
 #' @return
 #' A **ggplot2** layer or [ggplot2::theme()] object that can be
@@ -91,7 +91,7 @@
 #' }
 #'
 #' \subsection{Superimpose a function on an existing plot}{
-#' * `overlay_function()` is a simple wrapper for [ggplot2::geom_function()] but
+#' * `overlay_function()` is a simple wrapper for [ggplot2::stat_function()] but
 #'   with the `inherit.aes` argument fixed to `FALSE`. Fixing `inherit.aes=FALSE`
 #'   will avoid potential errors due to the [ggplot2::aes()]thetic mapping used by
 #'   certain **bayesplot** plotting functions.
@@ -476,7 +476,7 @@ grid_lines_y <- function(color = "gray50", linewidth = 0.2) {
 #' @rdname bayesplot-helpers
 #' @export
 overlay_function <- function(...) {
-  geom_function(..., inherit.aes = FALSE)
+  stat_function(..., inherit.aes = FALSE)
 }
 
 

--- a/man/bayesplot-helpers.Rd
+++ b/man/bayesplot-helpers.Rd
@@ -90,7 +90,7 @@ For \code{xaxis_ticks} and \code{yaxis_ticks}, \code{...} is passed to
 \code{\link[ggplot2:element]{ggplot2::element_line()}}.
 
 For \code{overlay_function}, \code{...} is passed to
-\code{\link[ggplot2:geom_function]{ggplot2::geom_function()}}.}
+\code{\link[ggplot2:geom_function]{ggplot2::stat_function()}}.}
 
 \item{na.rm}{A logical scalar passed to the appropriate geom (e.g.
 \code{\link[ggplot2:geom_abline]{ggplot2::geom_vline()}}). The default is \code{TRUE}.}
@@ -191,7 +191,7 @@ an existing plot (ggplot object) to add grid lines to the plot background.
 
 \subsection{Superimpose a function on an existing plot}{
 \itemize{
-\item \code{overlay_function()} is a simple wrapper for \code{\link[ggplot2:geom_function]{ggplot2::geom_function()}} but
+\item \code{overlay_function()} is a simple wrapper for \code{\link[ggplot2:geom_function]{ggplot2::stat_function()}} but
 with the \code{inherit.aes} argument fixed to \code{FALSE}. Fixing \code{inherit.aes=FALSE}
 will avoid potential errors due to the \code{\link[ggplot2:aes]{ggplot2::aes()}}thetic mapping used by
 certain \strong{bayesplot} plotting functions.

--- a/tests/testthat/test-convenience-functions.R
+++ b/tests/testthat/test-convenience-functions.R
@@ -180,8 +180,9 @@ test_that("yaxis_ticks returns correct theme object", {
 
 # overlay functions -------------------------------------------------------
 test_that("overlay_function returns the correct object", {
+  expect_error(overlay_function(), 'argument "fun" is missing')
   a <- overlay_function(fun = "dnorm")
-  b <- geom_function(fun = "dnorm", inherit.aes = FALSE)
+  b <- stat_function(fun = "dnorm", inherit.aes = FALSE)
   a$constructor <- b$constructor <- NULL
   expect_equal(a, b, ignore_function_env = TRUE)
 })


### PR DESCRIPTION
Fixes the `override.aes` in the `linetype` legend for `mcmc_trace()` divergence plots — changes `size` to `linewidth`, which is the correct aesthetic for line widths since ggplot2 3.4.0.

The `stat_function` -> `geom_function` change has been reverted per review feedback.