### PR TITLE
Add prior predictive checking section to PPC vignette (#196)

### DIFF
--- a/vignettes/graphical-ppcs.Rmd
+++ b/vignettes/graphical-ppcs.Rmd
@@ -314,45 +314,6 @@ See Figure 8 in [Gabry et al. (2019)](#gabry2019) for another example of using
 
 <br>
 
-## Using PPC plots for prior predictive checking
-
-Although this vignette focuses on *posterior* predictive checking, the same
-`ppc_*` functions can be used for **prior** predictive checking as well. The
-idea is the same: instead of passing draws from the posterior predictive
-distribution as `yrep`, you pass draws from the **prior** predictive
-distribution. This can be useful for understanding the implications of your
-priors before conditioning on the data (see Gabry et al. (2019) for more on
-when prior predictive checks are useful).
-
-For example, with **rstanarm** you can obtain prior predictive draws using
-`posterior_predict()` on a model fit with `prior_PD = TRUE`:
-
-```{r prior-pd, eval=FALSE}
-fit_prior <- stan_glm(
-  y ~ roach100 + treatment + senior,
-  offset = log(exposure2),
-  family = poisson,
-  data = roaches,
-  prior_PD = TRUE  # sample from prior predictive only
-)
-yrep_prior <- posterior_predict(fit_prior)
-
-# use the same ppc_ functions with prior predictive draws
-ppc_dens_overlay(y, yrep_prior[1:50, ])
-ppc_stat(y, yrep_prior, stat = "mean")
-```
-
-If you want to examine the prior predictive distribution *without* comparing to
-observed data, you can use the `ppd_*` functions (PPD = prior/posterior
-predictive distribution) instead:
-
-```{r ppd-example, eval=FALSE}
-ppd_dens_overlay(yrep_prior[1:50, ])
-ppd_stat(yrep_prior, stat = "mean")
-```
-
-<br>
-
 ## Providing an interface to bayesplot PPCs from another package
 
 The **bayesplot** package provides the S3 generic function `pp_check`. Authors of
@@ -422,6 +383,45 @@ Several packages currently use this approach to provide an interface to
 `pp_check` methods in the [**rstanarm**](https://CRAN.R-project.org/package=rstanarm) 
 and [**brms**](https://CRAN.R-project.org/package=brms) packages.
 
+
+<br>
+
+## Using PPC plots for prior predictive checking
+
+Although this vignette focuses on *posterior* predictive checking, the same
+`ppc_*` functions can be used for **prior** predictive checking as well. The
+idea is the same: instead of passing draws from the posterior predictive
+distribution as `yrep`, you pass draws from the **prior** predictive
+distribution. This can be useful for understanding the implications of your
+priors before conditioning on the data (see Gabry et al. (2019) for more on
+when prior predictive checks are useful).
+
+For example, with **rstanarm** you can obtain prior predictive draws using
+`posterior_predict()` on a model fit with `prior_PD = TRUE`:
+
+```{r prior-pd, eval=FALSE}
+fit_prior <- stan_glm(
+  y ~ roach100 + treatment + senior,
+  offset = log(exposure2),
+  family = poisson,
+  data = roaches,
+  prior_PD = TRUE  # sample from prior predictive only
+)
+yrep_prior <- posterior_predict(fit_prior)
+
+# use the same ppc_ functions with prior predictive draws
+ppc_dens_overlay(y, yrep_prior[1:50, ])
+ppc_stat(y, yrep_prior, stat = "mean")
+```
+
+If you want to examine the prior predictive distribution *without* comparing to
+observed data, you can use the `ppd_*` functions (PPD = prior/posterior
+predictive distribution) instead:
+
+```{r ppd-example, eval=FALSE}
+ppd_dens_overlay(yrep_prior[1:50, ])
+ppd_stat(yrep_prior, stat = "mean")
+```
 
 <br>
 


### PR DESCRIPTION
Advances #196.

Added a section to the graphical PPCs vignette explaining that the same `ppc_*` functions work for prior predictive checking — just pass draws from the prior predictive distribution instead of the posterior. Includes a `rstanarm` example using `prior_PD = TRUE` and mentions the `ppd_*` functions for when you don't want to compare against observed data.