### PR TITLE
Fix deprecated size aesthetic in mcmc_scatter examples (#467)

### DIFF
--- a/R/mcmc-scatterplots.R
+++ b/R/mcmc-scatterplots.R
@@ -98,12 +98,12 @@
 #'    )
 #'
 #' # add ellipse
-#' p + stat_ellipse(level = 0.9, color = "gray20", size = 1)
+#' p + stat_ellipse(level = 0.9, color = "gray20", linewidth = 1)
 #'
 #' # add contour
 #' color_scheme_set("red")
 #' p2 <- mcmc_scatter(x, pars = c("alpha", "sigma"), size = 3.5, alpha = 0.25)
-#' p2 + stat_density_2d(color = "black", size = .5)
+#' p2 + stat_density_2d(color = "black", linewidth = .5)
 #'
 #' # can also add lines/smooths
 #' color_scheme_set("pink")

--- a/man/MCMC-scatterplots.Rd
+++ b/man/MCMC-scatterplots.Rd
@@ -302,12 +302,12 @@ p +
    )
 
 # add ellipse
-p + stat_ellipse(level = 0.9, color = "gray20", size = 1)
+p + stat_ellipse(level = 0.9, color = "gray20", linewidth = 1)
 
 # add contour
 color_scheme_set("red")
 p2 <- mcmc_scatter(x, pars = c("alpha", "sigma"), size = 3.5, alpha = 0.25)
-p2 + stat_density_2d(color = "black", size = .5)
+p2 + stat_density_2d(color = "black", linewidth = .5)
 
 # can also add lines/smooths
 color_scheme_set("pink")


### PR DESCRIPTION
Fixes #467.

The `mcmc_scatter()` examples use `size` with `stat_ellipse()` and `stat_density_2d()`, which triggers a deprecation warning since ggplot2 3.4.0. Switched to `linewidth`.