### PR TITLE
Replace superseded coord_flip() with swapped aesthetics (#476)

### DIFF
--- a/R/ppc-errors.R
+++ b/R/ppc-errors.R
@@ -243,22 +243,22 @@ ppc_error_scatter_avg <-
 
     stat <- as_tagged_function({{ stat }})
 
-    ppc_scatter_avg(
+    p <- ppc_scatter_avg(
       y = if (is_null(x)) y else x,
       yrep = errors,
       size = size,
       alpha = alpha,
       ref_line = FALSE,
       stat = stat
-    ) +
-      labs(
-        x = error_avg_label(stat),
-        y = if (is_null(x)) y_label() else as_label((qx))
-        ) + if (is_null(x)) {
-          NULL
-        } else {
-          coord_flip()
-        }
+    )
+
+    if (is_null(x)) {
+      p + labs(x = error_avg_label(stat), y = y_label())
+    } else {
+      p +
+        aes(x = .data$y_obs, y = .data$value) +
+        labs(x = as_label((qx)), y = error_avg_label(stat))
+    }
   }
 
 
@@ -323,11 +323,11 @@ ppc_error_scatter_avg_vs_x <- function(
     ref_line = FALSE,
     stat = stat
   ) +
+    aes(x = .data$y_obs, y = .data$value) +
     labs(
-      x = error_avg_label(stat),
-      y = as_label((qx))
-    ) +
-    coord_flip()
+      x = as_label((qx)),
+      y = error_avg_label(stat)
+    )
 }
 
 


### PR DESCRIPTION
Fixes #476.

`coord_flip()` is marked `[Superseded]` in ggplot2 — replaced with direct aesthetic swapping in `ppc_error_scatter_avg()` and the deprecated `ppc_error_scatter_avg_vs_x()`.

Instead of building the plot with the axes one way and then flipping with `coord_flip()`, the x and y aesthetics are now mapped directly to the intended axes. Visual output is identical (all vdiffr snapshots pass unchanged).

https://ggplot2.tidyverse.org/reference/coord_flip.html