### PR TITLE
Fix melt_mcmc.mcmc_array() silently ignoring the as.is argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # bayesplot (development version)
 
-* Fix `melt_mcmc.mcmc_array()` ignoring the `as.is` argument — the value passed by the caller is now forwarded correctly to `reshape2::melt()` instead of being silently overridden with `FALSE`.
+* Remove unexposed `as.is` parameter from `melt_mcmc.mcmc_array()` — the argument was accepted in the signature but could not safely be set to `TRUE` since `reshape2::melt()` requires `as.is = FALSE` to correctly convert iteration and chain dimnames from character to numeric.
 * Use `rlang::warn()` and `rlang::inform()` for selected PPC user messages instead of base `warning()` and `message()`.
 * Standardize input validation errors in `ppc_km_overlay()` and interpolation helpers to use `rlang::abort()` for consistent error handling.
 * Fix assignment-in-call bug in `mcmc_rank_ecdf()` (#).

--- a/R/helpers-mcmc.R
+++ b/R/helpers-mcmc.R
@@ -130,7 +130,6 @@ melt_mcmc.mcmc_array <- function(x,
                                  varnames =
                                    c("Iteration", "Chain", "Parameter"),
                                  value.name = "Value",
-                                 as.is = TRUE,
                                  ...) {
   stopifnot(is_mcmc_array(x))
 
@@ -138,7 +137,7 @@ melt_mcmc.mcmc_array <- function(x,
     data = x,
     varnames = varnames,
     value.name = value.name,
-    as.is = as.is,
+    as.is = FALSE,
     ...)
 
   long$Parameter <- factor(long$Parameter)


### PR DESCRIPTION
Fixes #480 
`as.is` was hardcoded to `FALSE` inside the function regardless of what the caller passed. Changed it to forward the argument correctly. Default behavior is unchanged since the signature already defaults to `TRUE`, and the `Parameter` column is still explicitly converted to a factor after melting
(see `R/helpers-mcmc.R` line 144), so that behavior is unaffected by this fix.

Reference: https://www.rdocumentation.org/packages/reshape2/topics/melt.array
