### PR TITLE
Replace select(-c(col)) with select(-all_of(col))

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * New functions `mcmc_dots` and `mcmc_dots_by_chain` for dot plots of MCMC draws by @behramulukir (#402)
 * Default to `quantiles=100` for all dot plots by @behramulukir (#402)
 * Use `"neff_ratio"` consistently in diagnostic color scale helpers to avoid relying on partial matching of `"neff"`.
+* Replace deprecated `select(-c("col"))` with `select(-all_of("col"))` in `mcmc-intervals.R` to avoid dplyr warnings.
 
 # bayesplot 1.15.0
 

--- a/R/mcmc-intervals.R
+++ b/R/mcmc-intervals.R
@@ -756,7 +756,7 @@ mcmc_areas_data <- function(x,
       interval_width = 0,
       interval = "point"
     ) %>%
-    select(-c("center"), "m") %>%
+    select(-all_of("center"), all_of("m")) %>%
     ungroup()
 
   # Ignore points calculcation if no point estimate was requested
@@ -842,7 +842,7 @@ compute_column_density <- function(df, group_vars, value_var, ...) {
   reconstructed <- as.list(seq_len(nrow(nested)))
   for (df_i in seq_along(nested$density)) {
     row <- nested[df_i, ]
-    parent <- row %>% select(-c("density"))
+    parent <- row %>% select(-all_of("density"))
     groups <- rep(list(parent), nrow(row$density[[1]])) %>% dplyr::bind_rows()
 
     reconstructed[[df_i]] <- dplyr::bind_cols(groups, row$density[[1]])


### PR DESCRIPTION
Fixes #486 
**PR Description:**


- Replaced `select(-c("center"), "m")` and `select(-c("density"))` with `select(-all_of("center"), all_of("m"))` and `select(-all_of("density"))` in `mcmc-intervals.R` (lines 759, 845)
- Fixes deprecation warnings from dplyr 1.0.0+ when using character vectors inside `c()` for deselection in `select()`