### PR TITLE
Use geom_step() as default in ppc_ecdf_overlay() and deprecate discrete argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # bayesplot (development version)
 
-* `ppc_ecdf_overlay()`, `ppc_ecdf_overlay_grouped()`, and `ppd_ecdf_overlay()` now always use `geom_step()`. The `discrete` argument is deprecated .
+* `ppc_ecdf_overlay()`, `ppc_ecdf_overlay_grouped()`, and `ppd_ecdf_overlay()` now always use `geom_step()`. The `discrete` argument is deprecated.
 * Replace `apply()` with `storage.mode()` for integer-to-numeric matrix conversion in `validate_predictions()`.
 * Fixed `is_chain_list()` to correctly reject empty lists instead of silently returning `TRUE`.
 * Added unit tests for `mcmc_areas_ridges_data()`, `mcmc_parcoord_data()`, and `mcmc_trace_data()`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # bayesplot (development version)
 
+* `ppc_ecdf_overlay()`, `ppc_ecdf_overlay_grouped()`, and `ppd_ecdf_overlay()` now always use `geom_step()`. The `discrete` argument is deprecated .
 * Replace `apply()` with `storage.mode()` for integer-to-numeric matrix conversion in `validate_predictions()`.
 * Fixed `is_chain_list()` to correctly reject empty lists instead of silently returning `TRUE`.
 * Added unit tests for `mcmc_areas_ridges_data()`, `mcmc_parcoord_data()`, and `mcmc_trace_data()`.

--- a/R/ppc-distributions.R
+++ b/R/ppc-distributions.R
@@ -43,8 +43,8 @@
 #'          `ppc_ecdf_overlay_grouped()`, `ppc_dens_overlay_grouped()`}{
 #'    Kernel density or empirical CDF estimates of each dataset (row) in
 #'    `yrep` are overlaid, with the distribution of `y` itself on top
-#'    (and in a darker shade). When using `ppc_ecdf_overlay()` with discrete
-#'    data, set the `discrete` argument to `TRUE` for better results.
+#'    (and in a darker shade). `ppc_ecdf_overlay()` uses step functions,
+#'    consistent with the mathematical definition of the ECDF.
 #'    For an example of `ppc_dens_overlay()` also see Gabry et al. (2019).
 #'   }
 #'   \item{`ppc_violin_grouped()`}{
@@ -85,7 +85,7 @@
 #'
 #' ppc_dens_overlay(y, yrep[1:25, ])
 #' \donttest{
-#' # ppc_ecdf_overlay with continuous data (set discrete=TRUE if discrete data)
+#' # ppc_ecdf_overlay (always uses step functions)
 #' ppc_ecdf_overlay(y, yrep[sample(nrow(yrep), 25), ])
 #'
 #' # PIT-ECDF and PIT-ECDF difference plot of the PIT values of y compared to
@@ -258,20 +258,29 @@ ppc_dens_overlay_grouped <- function(y,
 
 #' @export
 #' @rdname PPC-distributions
-#' @param discrete For `ppc_ecdf_overlay()`, should the data be treated as
-#'   discrete? The default is `FALSE`, in which case `geom="line"` is
-#'   passed to [ggplot2::stat_ecdf()]. If `discrete` is set to
-#'   `TRUE` then `geom="step"` is used.
+#' @param discrete
+#'   `r lifecycle::badge("deprecated")` The `discrete` argument is
+#'   deprecated. The ECDF is a step function by definition, so `geom_step()`
+#'   is now always used.
 #' @param pad A logical scalar passed to [ggplot2::stat_ecdf()].
 #'
 ppc_ecdf_overlay <- function(y,
                              yrep,
                              ...,
-                             discrete = FALSE,
+                             discrete = deprecated(),
                              pad = TRUE,
                              size = 0.25,
                              alpha = 0.7) {
   check_ignored_arguments(...)
+
+  if (is_present(discrete)) {
+    deprecate_warn(
+      "1.12.0",
+      "ppc_ecdf_overlay(discrete)",
+      details = "The ECDF is now always plotted as a step function."
+    )
+  }
+
   data <- ppc_data(y, yrep)
 
   ggplot(data) +
@@ -291,7 +300,7 @@ ppc_ecdf_overlay <- function(y,
     stat_ecdf(
       data = function(x) dplyr::filter(x, !.data$is_y),
       mapping = aes(group = .data$rep_id, color = "yrep"),
-      geom = if (discrete) "step" else "line",
+      geom = "step",
       linewidth = size,
       alpha = alpha,
       pad = pad
@@ -299,7 +308,7 @@ ppc_ecdf_overlay <- function(y,
     stat_ecdf(
       data = function(x) dplyr::filter(x, .data$is_y),
       mapping = aes(color = "y"),
-      geom = if (discrete) "step" else "line",
+      geom = "step",
       linewidth = 1,
       pad = pad
     ) +
@@ -316,17 +325,24 @@ ppc_ecdf_overlay_grouped <- function(y,
                                      yrep,
                                      group,
                                      ...,
-                                     discrete = FALSE,
+                                     discrete = deprecated(),
                                      pad = TRUE,
                                      size = 0.25,
                                      alpha = 0.7) {
   check_ignored_arguments(...)
 
+  if (is_present(discrete)) {
+    deprecate_warn(
+      "1.12.0",
+      "ppc_ecdf_overlay_grouped(discrete)",
+      details = "The ECDF is now always plotted as a step function."
+    )
+  }
+
   p_overlay <- ppc_ecdf_overlay(
     y = y,
     yrep = yrep,
     ...,
-    discrete = discrete,
     pad = pad,
     size = size,
     alpha = alpha

--- a/R/ppc-distributions.R
+++ b/R/ppc-distributions.R
@@ -275,7 +275,7 @@ ppc_ecdf_overlay <- function(y,
 
   if (is_present(discrete)) {
     deprecate_warn(
-      "1.12.0",
+      "1.16.0",
       "ppc_ecdf_overlay(discrete)",
       details = "The ECDF is now always plotted as a step function."
     )
@@ -333,7 +333,7 @@ ppc_ecdf_overlay_grouped <- function(y,
 
   if (is_present(discrete)) {
     deprecate_warn(
-      "1.12.0",
+      "1.16.0",
       "ppc_ecdf_overlay_grouped(discrete)",
       details = "The ECDF is now always plotted as a step function."
     )

--- a/R/ppc-distributions.R
+++ b/R/ppc-distributions.R
@@ -41,11 +41,10 @@
 #'   }
 #'   \item{`ppc_ecdf_overlay()`, `ppc_dens_overlay()`,
 #'          `ppc_ecdf_overlay_grouped()`, `ppc_dens_overlay_grouped()`}{
-#'    Kernel density or empirical CDF estimates of each dataset (row) in
-#'    `yrep` are overlaid, with the distribution of `y` itself on top
-#'    (and in a darker shade). `ppc_ecdf_overlay()` uses step functions,
-#'    consistent with the mathematical definition of the ECDF.
-#'    For an example of `ppc_dens_overlay()` also see Gabry et al. (2019).
+#'    Kernel density or empirical CDF estimates of each dataset (row) in `yrep`
+#'    are overlaid, with the distribution of `y` itself on top (and in a darker
+#'    shade). For an example of `ppc_dens_overlay()` also see Gabry et al.
+#'    (2019).
 #'   }
 #'   \item{`ppc_violin_grouped()`}{
 #'    The density estimate of `yrep` within each level of a grouping
@@ -85,7 +84,7 @@
 #'
 #' ppc_dens_overlay(y, yrep[1:25, ])
 #' \donttest{
-#' # ppc_ecdf_overlay (always uses step functions)
+#' # ppc_ecdf_overlay
 #' ppc_ecdf_overlay(y, yrep[sample(nrow(yrep), 25), ])
 #'
 #' # PIT-ECDF and PIT-ECDF difference plot of the PIT values of y compared to
@@ -258,10 +257,9 @@ ppc_dens_overlay_grouped <- function(y,
 
 #' @export
 #' @rdname PPC-distributions
-#' @param discrete
-#'   `r lifecycle::badge("deprecated")` The `discrete` argument is
-#'   deprecated. The ECDF is a step function by definition, so `geom_step()`
-#'   is now always used.
+#' @param discrete `r lifecycle::badge("deprecated")` The `discrete` argument is
+#'   deprecated. The ECDF is a step function by definition, so `geom_step()` is
+#'   now always used.
 #' @param pad A logical scalar passed to [ggplot2::stat_ecdf()].
 #'
 ppc_ecdf_overlay <- function(y,

--- a/R/ppd-distributions.R
+++ b/R/ppd-distributions.R
@@ -83,11 +83,19 @@ ppd_dens_overlay <-
 ppd_ecdf_overlay <-
   function(ypred,
            ...,
-           discrete = FALSE,
+           discrete = deprecated(),
            pad = TRUE,
            size = 0.25,
            alpha = 0.7) {
     check_ignored_arguments(...)
+
+    if (is_present(discrete)) {
+      deprecate_warn(
+        "1.12.0",
+        "ppd_ecdf_overlay(discrete)",
+        details = "The ECDF is now always plotted as a step function."
+      )
+    }
 
     data <- ppd_data(ypred)
     ggplot(data, mapping = aes(x = .data$value)) +
@@ -99,7 +107,7 @@ ppd_ecdf_overlay <-
       ) +
       stat_ecdf(
         mapping = aes(group = .data$rep_id, color = "ypred"),
-        geom = if (discrete) "step" else "line",
+        geom = "step",
         linewidth = size,
         alpha = alpha,
         pad = pad

--- a/R/ppd-distributions.R
+++ b/R/ppd-distributions.R
@@ -91,7 +91,7 @@ ppd_ecdf_overlay <-
 
     if (is_present(discrete)) {
       deprecate_warn(
-        "1.12.0",
+        "1.16.0",
         "ppd_ecdf_overlay(discrete)",
         details = "The ECDF is now always plotted as a step function."
       )

--- a/man/PPC-distributions.Rd
+++ b/man/PPC-distributions.Rd
@@ -175,8 +175,8 @@ default kernel density estimation parameters or truncate the density
 support. \code{n_dens} defaults to \code{1024}.}
 
 \item{discrete}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The \code{discrete} argument is
-deprecated. The ECDF is a step function by definition, so \code{geom_step()}
-is now always used.}
+deprecated. The ECDF is a step function by definition, so \code{geom_step()} is
+now always used.}
 
 \item{pad}{A logical scalar passed to \code{\link[ggplot2:stat_ecdf]{ggplot2::stat_ecdf()}}.}
 
@@ -282,11 +282,10 @@ variable for \code{y} and each dataset (row) in \code{yrep}. For this plot
 }
 \item{\code{ppc_ecdf_overlay()}, \code{ppc_dens_overlay()},
 \code{ppc_ecdf_overlay_grouped()}, \code{ppc_dens_overlay_grouped()}}{
-Kernel density or empirical CDF estimates of each dataset (row) in
-\code{yrep} are overlaid, with the distribution of \code{y} itself on top
-(and in a darker shade). \code{ppc_ecdf_overlay()} uses step functions,
-consistent with the mathematical definition of the ECDF.
-For an example of \code{ppc_dens_overlay()} also see Gabry et al. (2019).
+Kernel density or empirical CDF estimates of each dataset (row) in \code{yrep}
+are overlaid, with the distribution of \code{y} itself on top (and in a darker
+shade). For an example of \code{ppc_dens_overlay()} also see Gabry et al.
+(2019).
 }
 \item{\code{ppc_violin_grouped()}}{
 The density estimate of \code{yrep} within each level of a grouping
@@ -322,7 +321,7 @@ dim(yrep)
 
 ppc_dens_overlay(y, yrep[1:25, ])
 \donttest{
-# ppc_ecdf_overlay (always uses step functions)
+# ppc_ecdf_overlay
 ppc_ecdf_overlay(y, yrep[sample(nrow(yrep), 25), ])
 
 # PIT-ECDF and PIT-ECDF difference plot of the PIT values of y compared to

--- a/man/PPC-distributions.Rd
+++ b/man/PPC-distributions.Rd
@@ -53,7 +53,7 @@ ppc_ecdf_overlay(
   y,
   yrep,
   ...,
-  discrete = FALSE,
+  discrete = deprecated(),
   pad = TRUE,
   size = 0.25,
   alpha = 0.7
@@ -64,7 +64,7 @@ ppc_ecdf_overlay_grouped(
   yrep,
   group,
   ...,
-  discrete = FALSE,
+  discrete = deprecated(),
   pad = TRUE,
   size = 0.25,
   alpha = 0.7
@@ -174,10 +174,9 @@ the predictive distributions.}
 default kernel density estimation parameters or truncate the density
 support. \code{n_dens} defaults to \code{1024}.}
 
-\item{discrete}{For \code{ppc_ecdf_overlay()}, should the data be treated as
-discrete? The default is \code{FALSE}, in which case \code{geom="line"} is
-passed to \code{\link[ggplot2:stat_ecdf]{ggplot2::stat_ecdf()}}. If \code{discrete} is set to
-\code{TRUE} then \code{geom="step"} is used.}
+\item{discrete}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The \code{discrete} argument is
+deprecated. The ECDF is a step function by definition, so \code{geom_step()}
+is now always used.}
 
 \item{pad}{A logical scalar passed to \code{\link[ggplot2:stat_ecdf]{ggplot2::stat_ecdf()}}.}
 
@@ -285,8 +284,8 @@ variable for \code{y} and each dataset (row) in \code{yrep}. For this plot
 \code{ppc_ecdf_overlay_grouped()}, \code{ppc_dens_overlay_grouped()}}{
 Kernel density or empirical CDF estimates of each dataset (row) in
 \code{yrep} are overlaid, with the distribution of \code{y} itself on top
-(and in a darker shade). When using \code{ppc_ecdf_overlay()} with discrete
-data, set the \code{discrete} argument to \code{TRUE} for better results.
+(and in a darker shade). \code{ppc_ecdf_overlay()} uses step functions,
+consistent with the mathematical definition of the ECDF.
 For an example of \code{ppc_dens_overlay()} also see Gabry et al. (2019).
 }
 \item{\code{ppc_violin_grouped()}}{
@@ -323,7 +322,7 @@ dim(yrep)
 
 ppc_dens_overlay(y, yrep[1:25, ])
 \donttest{
-# ppc_ecdf_overlay with continuous data (set discrete=TRUE if discrete data)
+# ppc_ecdf_overlay (always uses step functions)
 ppc_ecdf_overlay(y, yrep[sample(nrow(yrep), 25), ])
 
 # PIT-ECDF and PIT-ECDF difference plot of the PIT values of y compared to

--- a/man/PPD-distributions.Rd
+++ b/man/PPD-distributions.Rd
@@ -31,7 +31,7 @@ ppd_dens_overlay(
 ppd_ecdf_overlay(
   ypred,
   ...,
-  discrete = FALSE,
+  discrete = deprecated(),
   pad = TRUE,
   size = 0.25,
   alpha = 0.7
@@ -89,10 +89,9 @@ the predictive distributions.}
 default kernel density estimation parameters or truncate the density
 support. \code{n_dens} defaults to \code{1024}.}
 
-\item{discrete}{For \code{ppc_ecdf_overlay()}, should the data be treated as
-discrete? The default is \code{FALSE}, in which case \code{geom="line"} is
-passed to \code{\link[ggplot2:stat_ecdf]{ggplot2::stat_ecdf()}}. If \code{discrete} is set to
-\code{TRUE} then \code{geom="step"} is used.}
+\item{discrete}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The \code{discrete} argument is
+deprecated. The ECDF is a step function by definition, so \code{geom_step()}
+is now always used.}
 
 \item{pad}{A logical scalar passed to \code{\link[ggplot2:stat_ecdf]{ggplot2::stat_ecdf()}}.}
 

--- a/man/PPD-distributions.Rd
+++ b/man/PPD-distributions.Rd
@@ -90,8 +90,8 @@ default kernel density estimation parameters or truncate the density
 support. \code{n_dens} defaults to \code{1024}.}
 
 \item{discrete}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The \code{discrete} argument is
-deprecated. The ECDF is a step function by definition, so \code{geom_step()}
-is now always used.}
+deprecated. The ECDF is a step function by definition, so \code{geom_step()} is
+now always used.}
 
 \item{pad}{A logical scalar passed to \code{\link[ggplot2:stat_ecdf]{ggplot2::stat_ecdf()}}.}
 

--- a/tests/testthat/_snaps/ppc-distributions/ppc-ecdf-overlay-default.svg
+++ b/tests/testthat/_snaps/ppc-distributions/ppc-ecdf-overlay-default.svg
@@ -28,17 +28,17 @@
 <line x1='24.70' y1='290.45' x2='646.17' y2='290.45' style='stroke-width: 0.21; stroke: #011F4B; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
 <line x1='24.70' y1='531.90' x2='646.17' y2='531.90' style='stroke-width: 0.43; stroke: #011F4B; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
 <line x1='24.70' y1='49.00' x2='646.17' y2='49.00' style='stroke-width: 0.43; stroke: #011F4B; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
-<polyline points='24.70,531.90 52.95,435.32 165.94,161.68 278.94,81.19 391.93,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,531.90 52.95,322.64 165.94,161.68 278.94,65.10 391.93,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,531.90 52.95,338.74 165.94,193.87 278.94,81.19 391.93,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,531.90 52.95,387.03 165.94,242.16 278.94,129.48 391.93,81.19 504.92,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,531.90 52.95,370.93 165.94,177.77 278.94,113.39 391.93,65.10 504.92,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,531.90 52.95,322.64 165.94,113.39 278.94,65.10 391.93,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,531.90 52.95,354.84 165.94,161.68 278.94,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,531.90 52.95,354.84 165.94,209.97 278.94,113.39 391.93,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,531.90 52.95,370.93 165.94,145.58 278.94,81.19 391.93,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,531.90 52.95,242.16 165.94,97.29 278.94,65.10 391.93,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,531.90 52.95,354.84 165.94,161.68 278.94,81.19 391.93,65.10 617.92,49.00 646.17,49.00 ' style='stroke-width: 2.13; stroke: #011F4B; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 52.95,531.90 52.95,435.32 165.94,435.32 165.94,161.68 278.94,161.68 278.94,81.19 391.93,81.19 391.93,49.00 646.17,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 52.95,531.90 52.95,322.64 165.94,322.64 165.94,161.68 278.94,161.68 278.94,65.10 391.93,65.10 391.93,49.00 646.17,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 52.95,531.90 52.95,338.74 165.94,338.74 165.94,193.87 278.94,193.87 278.94,81.19 391.93,81.19 391.93,49.00 646.17,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 52.95,531.90 52.95,387.03 165.94,387.03 165.94,242.16 278.94,242.16 278.94,129.48 391.93,129.48 391.93,81.19 504.92,81.19 504.92,49.00 646.17,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 52.95,531.90 52.95,370.93 165.94,370.93 165.94,177.77 278.94,177.77 278.94,113.39 391.93,113.39 391.93,65.10 504.92,65.10 504.92,49.00 646.17,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 52.95,531.90 52.95,322.64 165.94,322.64 165.94,113.39 278.94,113.39 278.94,65.10 391.93,65.10 391.93,49.00 646.17,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 52.95,531.90 52.95,354.84 165.94,354.84 165.94,161.68 278.94,161.68 278.94,49.00 646.17,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 52.95,531.90 52.95,354.84 165.94,354.84 165.94,209.97 278.94,209.97 278.94,113.39 391.93,113.39 391.93,49.00 646.17,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 52.95,531.90 52.95,370.93 165.94,370.93 165.94,145.58 278.94,145.58 278.94,81.19 391.93,81.19 391.93,49.00 646.17,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 52.95,531.90 52.95,242.16 165.94,242.16 165.94,97.29 278.94,97.29 278.94,65.10 391.93,65.10 391.93,49.00 646.17,49.00 646.17,49.00 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 52.95,531.90 52.95,354.84 165.94,354.84 165.94,161.68 278.94,161.68 278.94,81.19 391.93,81.19 391.93,65.10 617.92,65.10 617.92,49.00 646.17,49.00 646.17,49.00 ' style='stroke-width: 2.13; stroke: #011F4B; stroke-linecap: butt;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <polyline points='24.70,556.04 24.70,24.85 ' style='stroke-width: 0.85; stroke-linecap: butt;' />

--- a/tests/testthat/_snaps/ppc-distributions/ppc-ecdf-overlay-grouped-default.svg
+++ b/tests/testthat/_snaps/ppc-distributions/ppc-ecdf-overlay-grouped-default.svg
@@ -28,17 +28,17 @@
 <line x1='24.70' y1='300.07' x2='324.63' y2='300.07' style='stroke-width: 0.21; stroke: #011F4B; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
 <line x1='24.70' y1='532.77' x2='324.63' y2='532.77' style='stroke-width: 0.43; stroke: #011F4B; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
 <line x1='24.70' y1='67.36' x2='324.63' y2='67.36' style='stroke-width: 0.43; stroke: #011F4B; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
-<polyline points='24.70,532.77 38.34,470.72 92.87,160.45 147.40,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,532.77 38.34,222.50 92.87,160.45 147.40,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,532.77 38.34,315.58 92.87,160.45 147.40,98.39 201.94,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,532.77 38.34,439.69 92.87,315.58 147.40,160.45 201.94,98.39 256.47,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,532.77 38.34,315.58 92.87,160.45 147.40,98.39 201.94,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,532.77 38.34,346.61 92.87,98.39 147.40,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,532.77 38.34,346.61 92.87,129.42 147.40,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,532.77 38.34,315.58 92.87,160.45 147.40,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,532.77 38.34,253.53 92.87,98.39 147.40,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,532.77 38.34,191.47 92.87,98.39 147.40,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='24.70,532.77 38.34,439.69 92.87,253.53 147.40,129.42 201.94,98.39 311.00,67.36 324.63,67.36 ' style='stroke-width: 2.13; stroke: #011F4B; stroke-linecap: butt;' />
+<polyline points='24.70,532.77 38.34,532.77 38.34,470.72 92.87,470.72 92.87,160.45 147.40,160.45 147.40,67.36 324.63,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,532.77 38.34,532.77 38.34,222.50 92.87,222.50 92.87,160.45 147.40,160.45 147.40,67.36 324.63,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,532.77 38.34,532.77 38.34,315.58 92.87,315.58 92.87,160.45 147.40,160.45 147.40,98.39 201.94,98.39 201.94,67.36 324.63,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,532.77 38.34,532.77 38.34,439.69 92.87,439.69 92.87,315.58 147.40,315.58 147.40,160.45 201.94,160.45 201.94,98.39 256.47,98.39 256.47,67.36 324.63,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,532.77 38.34,532.77 38.34,315.58 92.87,315.58 92.87,160.45 147.40,160.45 147.40,98.39 201.94,98.39 201.94,67.36 324.63,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,532.77 38.34,532.77 38.34,346.61 92.87,346.61 92.87,98.39 147.40,98.39 147.40,67.36 324.63,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,532.77 38.34,532.77 38.34,346.61 92.87,346.61 92.87,129.42 147.40,129.42 147.40,67.36 324.63,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,532.77 38.34,532.77 38.34,315.58 92.87,315.58 92.87,160.45 147.40,160.45 147.40,67.36 324.63,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,532.77 38.34,532.77 38.34,253.53 92.87,253.53 92.87,98.39 147.40,98.39 147.40,67.36 324.63,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,532.77 38.34,532.77 38.34,191.47 92.87,191.47 92.87,98.39 147.40,98.39 147.40,67.36 324.63,67.36 324.63,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,532.77 38.34,532.77 38.34,439.69 92.87,439.69 92.87,253.53 147.40,253.53 147.40,129.42 201.94,129.42 201.94,98.39 311.00,98.39 311.00,67.36 324.63,67.36 324.63,67.36 ' style='stroke-width: 2.13; stroke: #011F4B; stroke-linecap: butt;' />
 <line x1='24.70' y1='556.04' x2='324.63' y2='556.04' style='stroke-width: 0.85; stroke-linecap: butt;' />
 <line x1='24.70' y1='556.04' x2='24.70' y2='44.09' style='stroke-width: 0.85; stroke-linecap: butt;' />
 </g>
@@ -53,17 +53,17 @@
 <line x1='346.23' y1='300.07' x2='646.17' y2='300.07' style='stroke-width: 0.21; stroke: #011F4B; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
 <line x1='346.23' y1='532.77' x2='646.17' y2='532.77' style='stroke-width: 0.43; stroke: #011F4B; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
 <line x1='346.23' y1='67.36' x2='646.17' y2='67.36' style='stroke-width: 0.43; stroke: #011F4B; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
-<polyline points='346.23,532.77 359.87,408.66 414.40,191.47 468.93,129.42 523.47,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='346.23,532.77 359.87,439.69 414.40,191.47 468.93,98.39 523.47,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='346.23,532.77 359.87,377.64 414.40,253.53 468.93,98.39 523.47,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='346.23,532.77 359.87,346.61 414.40,191.47 468.93,129.42 523.47,98.39 578.00,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='346.23,532.77 359.87,439.69 414.40,222.50 468.93,160.45 523.47,98.39 578.00,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='346.23,532.77 359.87,315.58 414.40,160.45 468.93,98.39 523.47,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='346.23,532.77 359.87,377.64 414.40,222.50 468.93,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='346.23,532.77 359.87,408.66 414.40,284.55 468.93,191.47 523.47,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='346.23,532.77 359.87,501.75 414.40,222.50 468.93,129.42 523.47,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='346.23,532.77 359.87,315.58 414.40,129.42 468.93,98.39 523.47,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
-<polyline points='346.23,532.77 359.87,284.55 414.40,98.39 468.93,67.36 646.17,67.36 ' style='stroke-width: 2.13; stroke: #011F4B; stroke-linecap: butt;' />
+<polyline points='346.23,532.77 359.87,532.77 359.87,408.66 414.40,408.66 414.40,191.47 468.93,191.47 468.93,129.42 523.47,129.42 523.47,67.36 646.17,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='346.23,532.77 359.87,532.77 359.87,439.69 414.40,439.69 414.40,191.47 468.93,191.47 468.93,98.39 523.47,98.39 523.47,67.36 646.17,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='346.23,532.77 359.87,532.77 359.87,377.64 414.40,377.64 414.40,253.53 468.93,253.53 468.93,98.39 523.47,98.39 523.47,67.36 646.17,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='346.23,532.77 359.87,532.77 359.87,346.61 414.40,346.61 414.40,191.47 468.93,191.47 468.93,129.42 523.47,129.42 523.47,98.39 578.00,98.39 578.00,67.36 646.17,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='346.23,532.77 359.87,532.77 359.87,439.69 414.40,439.69 414.40,222.50 468.93,222.50 468.93,160.45 523.47,160.45 523.47,98.39 578.00,98.39 578.00,67.36 646.17,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='346.23,532.77 359.87,532.77 359.87,315.58 414.40,315.58 414.40,160.45 468.93,160.45 468.93,98.39 523.47,98.39 523.47,67.36 646.17,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='346.23,532.77 359.87,532.77 359.87,377.64 414.40,377.64 414.40,222.50 468.93,222.50 468.93,67.36 646.17,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='346.23,532.77 359.87,532.77 359.87,408.66 414.40,408.66 414.40,284.55 468.93,284.55 468.93,191.47 523.47,191.47 523.47,67.36 646.17,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='346.23,532.77 359.87,532.77 359.87,501.75 414.40,501.75 414.40,222.50 468.93,222.50 468.93,129.42 523.47,129.42 523.47,67.36 646.17,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='346.23,532.77 359.87,532.77 359.87,315.58 414.40,315.58 414.40,129.42 468.93,129.42 468.93,98.39 523.47,98.39 523.47,67.36 646.17,67.36 646.17,67.36 ' style='stroke-width: 0.53; stroke: #B3CDE0; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='346.23,532.77 359.87,532.77 359.87,284.55 414.40,284.55 414.40,98.39 468.93,98.39 468.93,67.36 646.17,67.36 646.17,67.36 ' style='stroke-width: 2.13; stroke: #011F4B; stroke-linecap: butt;' />
 <line x1='346.23' y1='556.04' x2='646.17' y2='556.04' style='stroke-width: 0.85; stroke-linecap: butt;' />
 <line x1='346.23' y1='556.04' x2='346.23' y2='44.09' style='stroke-width: 0.85; stroke-linecap: butt;' />
 </g>

--- a/tests/testthat/_snaps/ppc-distributions/ppc-ecdf-overlay-grouped-size-alpha.svg
+++ b/tests/testthat/_snaps/ppc-distributions/ppc-ecdf-overlay-grouped-size-alpha.svg
@@ -128,6 +128,6 @@
 <text x='694.89' y='320.77' style='font-size: 9.10px; font-family: sans;' textLength='3.03px' lengthAdjust='spacingAndGlyphs'>r</text>
 <text x='697.92' y='320.77' style='font-size: 9.10px; font-family: sans;' textLength='5.06px' lengthAdjust='spacingAndGlyphs'>e</text>
 <text x='702.98' y='320.77' style='font-size: 9.10px; font-family: sans;' textLength='5.06px' lengthAdjust='spacingAndGlyphs'>p</text>
-<text x='24.70' y='15.89' style='font-size: 14.40px; font-family: sans;' textLength='314.63px' lengthAdjust='spacingAndGlyphs'>ppc_ecdf_overlay_grouped (discrete, size, alpha)</text>
+<text x='24.70' y='15.89' style='font-size: 14.40px; font-family: sans;' textLength='256.20px' lengthAdjust='spacingAndGlyphs'>ppc_ecdf_overlay_grouped (size, alpha)</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/ppc-distributions/ppc-ecdf-overlay-size-alpha.svg
+++ b/tests/testthat/_snaps/ppc-distributions/ppc-ecdf-overlay-size-alpha.svg
@@ -68,6 +68,6 @@
 <text x='694.89' y='311.15' style='font-size: 9.10px; font-family: sans;' textLength='3.03px' lengthAdjust='spacingAndGlyphs'>r</text>
 <text x='697.92' y='311.15' style='font-size: 9.10px; font-family: sans;' textLength='5.06px' lengthAdjust='spacingAndGlyphs'>e</text>
 <text x='702.98' y='311.15' style='font-size: 9.10px; font-family: sans;' textLength='5.06px' lengthAdjust='spacingAndGlyphs'>p</text>
-<text x='24.70' y='15.89' style='font-size: 14.40px; font-family: sans;' textLength='253.77px' lengthAdjust='spacingAndGlyphs'>ppc_ecdf_overlay (discrete, size, alpha)</text>
+<text x='24.70' y='15.89' style='font-size: 14.40px; font-family: sans;' textLength='195.34px' lengthAdjust='spacingAndGlyphs'>ppc_ecdf_overlay (size, alpha)</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/ppc-distributions/ppd-ecdf-overlay-default.svg
+++ b/tests/testthat/_snaps/ppc-distributions/ppd-ecdf-overlay-default.svg
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMjQuNzB8NzE0LjAyfDI0Ljg1fDU1Ni4wNA=='>
+    <rect x='24.70' y='24.85' width='689.32' height='531.19' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMjQuNzB8NzE0LjAyfDI0Ljg1fDU1Ni4wNA==)'>
+<line x1='24.70' y1='531.90' x2='714.02' y2='531.90' style='stroke-width: 0.43; stroke: #011F4B; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<line x1='24.70' y1='290.45' x2='714.02' y2='290.45' style='stroke-width: 0.21; stroke: #011F4B; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<line x1='24.70' y1='49.00' x2='714.02' y2='49.00' style='stroke-width: 0.43; stroke: #011F4B; stroke-dasharray: 4.00,4.00; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 56.04,531.90 56.04,435.32 212.70,435.32 212.70,161.68 369.36,161.68 369.36,81.19 526.03,81.19 526.03,49.00 714.02,49.00 714.02,49.00 ' style='stroke-width: 0.53; stroke: #6497B1; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 56.04,531.90 56.04,322.64 212.70,322.64 212.70,161.68 369.36,161.68 369.36,65.10 526.03,65.10 526.03,49.00 714.02,49.00 714.02,49.00 ' style='stroke-width: 0.53; stroke: #6497B1; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 56.04,531.90 56.04,338.74 212.70,338.74 212.70,193.87 369.36,193.87 369.36,81.19 526.03,81.19 526.03,49.00 714.02,49.00 714.02,49.00 ' style='stroke-width: 0.53; stroke: #6497B1; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 56.04,531.90 56.04,387.03 212.70,387.03 212.70,242.16 369.36,242.16 369.36,129.48 526.03,129.48 526.03,81.19 682.69,81.19 682.69,49.00 714.02,49.00 714.02,49.00 ' style='stroke-width: 0.53; stroke: #6497B1; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 56.04,531.90 56.04,370.93 212.70,370.93 212.70,177.77 369.36,177.77 369.36,113.39 526.03,113.39 526.03,65.10 682.69,65.10 682.69,49.00 714.02,49.00 714.02,49.00 ' style='stroke-width: 0.53; stroke: #6497B1; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 56.04,531.90 56.04,322.64 212.70,322.64 212.70,113.39 369.36,113.39 369.36,65.10 526.03,65.10 526.03,49.00 714.02,49.00 714.02,49.00 ' style='stroke-width: 0.53; stroke: #6497B1; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 56.04,531.90 56.04,354.84 212.70,354.84 212.70,161.68 369.36,161.68 369.36,49.00 714.02,49.00 714.02,49.00 ' style='stroke-width: 0.53; stroke: #6497B1; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 56.04,531.90 56.04,354.84 212.70,354.84 212.70,209.97 369.36,209.97 369.36,113.39 526.03,113.39 526.03,49.00 714.02,49.00 714.02,49.00 ' style='stroke-width: 0.53; stroke: #6497B1; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 56.04,531.90 56.04,370.93 212.70,370.93 212.70,145.58 369.36,145.58 369.36,81.19 526.03,81.19 526.03,49.00 714.02,49.00 714.02,49.00 ' style='stroke-width: 0.53; stroke: #6497B1; stroke-opacity: 0.70; stroke-linecap: butt;' />
+<polyline points='24.70,531.90 56.04,531.90 56.04,242.16 212.70,242.16 212.70,97.29 369.36,97.29 369.36,65.10 526.03,65.10 526.03,49.00 714.02,49.00 714.02,49.00 ' style='stroke-width: 0.53; stroke: #6497B1; stroke-opacity: 0.70; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='24.70,556.04 24.70,24.85 ' style='stroke-width: 0.85; stroke-linecap: butt;' />
+<text x='19.32' y='535.20' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='19.32' y='293.75' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>0.5</text>
+<text x='19.32' y='52.30' text-anchor='end' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='13.35px' lengthAdjust='spacingAndGlyphs'>1.0</text>
+<polyline points='21.71,531.90 24.70,531.90 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='21.71,290.45 24.70,290.45 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='21.71,49.00 24.70,49.00 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='24.70,556.04 714.02,556.04 ' style='stroke-width: 0.85; stroke-linecap: butt;' />
+<polyline points='56.04,559.03 56.04,556.04 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='212.70,559.03 212.70,556.04 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='369.36,559.03 369.36,556.04 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='526.03,559.03 526.03,556.04 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='682.69,559.03 682.69,556.04 ' style='stroke-width: 0.64; stroke: #333333; stroke-linecap: butt;' />
+<text x='56.04' y='568.03' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='5.34px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='212.70' y='568.03' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='5.34px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='369.36' y='568.03' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='5.34px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='526.03' y='568.03' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='5.34px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='682.69' y='568.03' text-anchor='middle' style='font-size: 9.60px; fill: #4D4D4D; font-family: sans;' textLength='5.34px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='24.70' y='15.89' style='font-size: 14.40px; font-family: sans;' textLength='170.53px' lengthAdjust='spacingAndGlyphs'>ppd_ecdf_overlay (default)</text>
+</g>
+</svg>

--- a/tests/testthat/test-ppc-distributions.R
+++ b/tests/testthat/test-ppc-distributions.R
@@ -50,6 +50,22 @@ test_that("ppc_ecdf_overlay returns a ggplot object", {
   expect_gg(ppd_ecdf_overlay(yrep2))
 })
 
+test_that("ppc_ecdf_overlay discrete argument is deprecated", {
+  lifecycle::expect_deprecated(
+    ppc_ecdf_overlay(vdiff_y2, vdiff_yrep2, discrete = TRUE)
+  )
+  lifecycle::expect_deprecated(
+    ppc_ecdf_overlay_grouped(vdiff_y2, vdiff_yrep2, vdiff_group2, discrete = TRUE)
+  )
+  lifecycle::expect_deprecated(
+    ppd_ecdf_overlay(vdiff_yrep2, discrete = TRUE)
+  )
+
+  # no warning when discrete is not supplied
+  expect_no_warning(ppc_ecdf_overlay(vdiff_y2, vdiff_yrep2))
+  expect_no_warning(ppd_ecdf_overlay(vdiff_yrep2))
+})
+
 test_that("ppc_dens,pp_hist,ppc_freqpoly,ppc_boxplot return ggplot objects", {
   expect_gg(ppc_hist(y, yrep[1,, drop = FALSE], binwidth = 0.1))
   expect_gg(ppc_hist(y, yrep[1:8, ], binwidth = 0.1))
@@ -390,22 +406,6 @@ test_that("ppc_ecdf_overlay_grouped renders correctly", {
     "ppc_ecdf_overlay_grouped (size, alpha)",
     p_custom
   )
-})
-
-test_that("ppc_ecdf_overlay discrete argument is deprecated", {
-  lifecycle::expect_deprecated(
-    ppc_ecdf_overlay(vdiff_y2, vdiff_yrep2, discrete = TRUE)
-  )
-  lifecycle::expect_deprecated(
-    ppc_ecdf_overlay_grouped(vdiff_y2, vdiff_yrep2, vdiff_group2, discrete = TRUE)
-  )
-  lifecycle::expect_deprecated(
-    ppd_ecdf_overlay(vdiff_yrep2, discrete = TRUE)
-  )
-
-  # no warning when discrete is not supplied
-  expect_no_warning(ppc_ecdf_overlay(vdiff_y2, vdiff_yrep2))
-  expect_no_warning(ppd_ecdf_overlay(vdiff_yrep2))
 })
 
 test_that("ppc_dens renders correctly", {

--- a/tests/testthat/test-ppc-distributions.R
+++ b/tests/testthat/test-ppc-distributions.R
@@ -408,6 +408,15 @@ test_that("ppc_ecdf_overlay_grouped renders correctly", {
   )
 })
 
+test_that("ppd_ecdf_overlay renders correctly", {
+  testthat::skip_on_cran()
+  testthat::skip_if_not_installed("vdiffr")
+  skip_on_r_oldrel()
+
+  p_base <- ppd_ecdf_overlay(vdiff_yrep2)
+  vdiffr::expect_doppelganger("ppd_ecdf_overlay (default)", p_base)
+})
+
 test_that("ppc_dens renders correctly", {
   testthat::skip_on_cran()
   testthat::skip_if_not_installed("vdiffr")

--- a/tests/testthat/test-ppc-distributions.R
+++ b/tests/testthat/test-ppc-distributions.R
@@ -360,13 +360,12 @@ test_that("ppc_ecdf_overlay renders correctly", {
   p_custom <- ppc_ecdf_overlay(
     vdiff_y2,
     vdiff_yrep2,
-    discrete = TRUE,
     size = 2,
     alpha = .2
   )
 
   vdiffr::expect_doppelganger(
-    "ppc_ecdf_overlay (discrete, size, alpha)",
+    "ppc_ecdf_overlay (size, alpha)",
     p_custom
   )
 })
@@ -383,15 +382,30 @@ test_that("ppc_ecdf_overlay_grouped renders correctly", {
     vdiff_y2,
     vdiff_yrep2,
     vdiff_group2,
-    discrete = TRUE,
     size = 2,
     alpha = .2
   )
 
   vdiffr::expect_doppelganger(
-    "ppc_ecdf_overlay_grouped (discrete, size, alpha)",
+    "ppc_ecdf_overlay_grouped (size, alpha)",
     p_custom
   )
+})
+
+test_that("ppc_ecdf_overlay discrete argument is deprecated", {
+  lifecycle::expect_deprecated(
+    ppc_ecdf_overlay(vdiff_y2, vdiff_yrep2, discrete = TRUE)
+  )
+  lifecycle::expect_deprecated(
+    ppc_ecdf_overlay_grouped(vdiff_y2, vdiff_yrep2, vdiff_group2, discrete = TRUE)
+  )
+  lifecycle::expect_deprecated(
+    ppd_ecdf_overlay(vdiff_yrep2, discrete = TRUE)
+  )
+
+  # no warning when discrete is not supplied
+  expect_no_warning(ppc_ecdf_overlay(vdiff_y2, vdiff_yrep2))
+  expect_no_warning(ppd_ecdf_overlay(vdiff_yrep2))
 })
 
 test_that("ppc_dens renders correctly", {


### PR DESCRIPTION
Fixes #259

The ECDF is a step function by definition, regardless of whether the data is continuous or discrete. `ppc_km_overlay()` already hard-codes `geom_step()` for the same reason. This PR makes `ppc_ecdf_overlay()` consistent.

## Changes

- `ppc_ecdf_overlay()`, `ppc_ecdf_overlay_grouped()`, and `ppd_ecdf_overlay()` now always use `geom = "step"` in `stat_ecdf()`
- The `discrete` argument is deprecated via `lifecycle::deprecate_warn()`
- Updated roxygen documentation and examples
- Regenerated vdiffr snapshots
- Added deprecation and no-warning tests

![before](https://github.com/user-attachments/assets/5ed6752c-aae1-44ff-bfa9-68fac52ad38f)
![after](https://github.com/user-attachments/assets/a49a4157-ab71-41d8-8d72-7c4dead40a5c)

