### PR TITLE
Added multiverse and stan universe to pkgdown GHA

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -30,6 +30,9 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          extra-repositories: |
+            https://community.r-multiverse.org
+            https://stan-dev.r-universe.dev
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
#399 added cmdstanr to GHA but failed to account for the pkgdown GHA. This PR rectifies that oversight.