### PR TITLE
Add AI contribution policy

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,3 +54,5 @@ new to you.
 Please note that the bayesplot project follows the Stan project's 
 [Code of Conduct](https://discourse.mc-stan.org/t/announcing-our-new-stan-code-of-conduct/23764).
 By contributing to this project you agree to abide by its terms.
+
+All contributions must follow the [Stan AI Contribution Policy](https://github.com/stan-dev/stan/wiki/AI-Contribution-Policy).


### PR DESCRIPTION
## Summary
This PR adds a reference to the Stan AI Contribution Policy (see Stan-wiki: https://github.com/stan-dev/stan/wiki/AI-Contribution-Policy) to the CONTRIBUTING.md so contributors are aware of it before submitting PRs.